### PR TITLE
Resolve installation issues in docker

### DIFF
--- a/platforms/centos6/centos6-packages.sh
+++ b/platforms/centos6/centos6-packages.sh
@@ -20,7 +20,7 @@
 # Install prerequisite packages for Centos6
 echo Installing standard extra packages using "yum"
 sudo yum -y groupinstall "development tools"
-echo Installing packages required: tcl pax python-devel fakeroot redhat-lsb-core
-sudo yum -y install tcl pax python-devel fakeroot redhat-lsb-core
+echo Installing packages required: tcl pax python-devel fakeroot redhat-lsb-core which
+sudo yum -y install tcl pax python-devel fakeroot redhat-lsb-core which
 echo Installing 32 bit libraries '(really only required for modelsim)'
 sudo yum -y install glibc.i686 libXft.i686 libXext.i686 ncurses-libs.i686

--- a/platforms/centos7/centos7-packages.sh
+++ b/platforms/centos7/centos7-packages.sh
@@ -20,7 +20,7 @@
 # Install prerequisite packages for Centos6
 echo Installing standard extra packages using "yum"
 sudo yum -y groupinstall "development tools"
-echo Installing packages required: tcl pax python-devel fakeroot
-sudo yum -y install tcl pax python-devel fakeroot
+echo Installing packages required: tcl pax python-devel fakeroot which
+sudo yum -y install tcl pax python-devel fakeroot which
 echo Installing 32 bit libraries '(really only required for modelsim)'
 sudo yum -y install glibc.i686 libXft.i686 libXext.i686 ncurses-libs.i686

--- a/tools/cdk/scripts/util.sh
+++ b/tools/cdk/scripts/util.sh
@@ -36,7 +36,7 @@ function findInProjectPath {
 function setVarsFromMake {
   local quiet
   [ -z "$3" ] && quiet=1   
-  [ -z $(which make 2> /dev/null) ] && {
+  [ -z $(command -v make 2> /dev/null) ] && {
     [ -n "$3" ] && echo The '"make"' command is not available. 2>&1
     return 1
   }


### PR DESCRIPTION
The `./scripts/install-opencpi.sh` was silently failing because `which` was not installed by default. This PR adds it to the default packages and then doesn't require it where it was failing.

Kernel driver doesn't build, but that's a whole other problem.