### PR TITLE
More problems we have found

### DIFF
--- a/example_zed_env.sh
+++ b/example_zed_env.sh
@@ -25,7 +25,7 @@ export OCPI_XILINX_DIR= #/opt/Xilinx
 export OCPI_XILINX_VERSION= #14.7
 export OCPI_XILINX_LICENSE_FILE= #$OCPI_XILINX_DIR/OCPI_XILINX_VERSION/License.lic
 
-OCPI_TARGET_PLATFORM=xilinx13_4
+export OCPI_TARGET_PLATFORM=xilinx13_4
 
 # #### Location of the Modelsim tools ####################################### #
 

--- a/platforms/centos6/centos6-packages.sh
+++ b/platforms/centos6/centos6-packages.sh
@@ -20,7 +20,7 @@
 # Install prerequisite packages for Centos6
 echo Installing standard extra packages using "yum"
 sudo yum -y groupinstall "development tools"
-echo Installing packages required: tcl pax python-devel fakeroot redhat-lsb-core
-sudo yum -y install tcl pax python-devel fakeroot redhat-lsb-core
+echo Installing packages required: tcl pax python-devel fakeroot redhat-lsb-core which
+sudo yum -y install tcl pax python-devel fakeroot redhat-lsb-core which
 echo Installing 32 bit libraries '(really only required for modelsim)'
 sudo yum -y install glibc.i686 libXft.i686 libXext.i686 ncurses-libs.i686

--- a/platforms/centos7/centos7-packages.sh
+++ b/platforms/centos7/centos7-packages.sh
@@ -20,7 +20,7 @@
 # Install prerequisite packages for Centos6
 echo Installing standard extra packages using "yum"
 sudo yum -y groupinstall "development tools"
-echo Installing packages required: tcl pax python-devel fakeroot
-sudo yum -y install tcl pax python-devel fakeroot
+echo Installing packages required: tcl pax python-devel fakeroot which
+sudo yum -y install tcl pax python-devel fakeroot which
 echo Installing 32 bit libraries '(really only required for modelsim)'
 sudo yum -y install glibc.i686 libXft.i686 libXext.i686 ncurses-libs.i686

--- a/runtime/hdl-support/scripts/ocpiview
+++ b/runtime/hdl-support/scripts/ocpiview
@@ -42,6 +42,16 @@ if test -f isim.wdb; then
 elif test -f vsim.wlf; then
   export LM_LICENSE_FILE=$OCPI_MODELSIM_LICENSE_FILE
   exec $OCPI_MODELSIM_DIR/bin/vsim -view vsim.wlf
+elif test -f xsim.wdb; then
+  setVarsFromMake $OCPI_CDK_DIR/include/hdl/xilinx.mk ShellIseVars=1 $verbose
+  [ -z "$OcpiXilinxVivadoDir" -o -z "$OcpiXilinxLicenseFile" ] && {
+    echo Could not find the Xilinx Vivado tools directory or license file. >&2
+    exit 1
+  }
+  set -e
+  . $OcpiXilinxVivadoDir/.settings64-Vivado.sh > /dev/null
+  export LM_LICENSE_FILE=$OcpiXilinxLicenseFile
+  exec xsim -gui xsim.wdb -tclbatch view.tcl
 else
   files=(`shopt -s nullglob; echo *.*sim.20*[0-9]`)
   nfiles=${#files[@]}
@@ -49,13 +59,13 @@ else
     if [ -d simulations ]; then
       exec sh $0 simulations
     fi
-    echo No simulation files \(isim.wdb or vsim.wlf\) nor simulation directories \(*.*sim.\<date\>\) found.
+    echo No simulation files \(xsim.wdb, isim.wdb or vsim.wlf\) nor simulation directories \(*.*sim.\<date\>\) found.
     exit 1
   fi
   files=(`ls -dtr ${files[*]}`)
   nfiles=${#files[@]}
   last=${files[$nfiles-1]}
-  if test -f $last/isim.wdb -o -f $last/vsim.wlf; then
+  if test -f $last/isim.wdb -o -f $last/vsim.wlf -o -f $last/xsim.wdb; then
     exec sh $0 $last
   fi
   echo Although a simulation directory was found \($last\), no sim files were found \($last/isim.wdb or $last/vsim.wlf\)

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -56,8 +56,8 @@ scripts/install-lzma.sh
 echo ================================================================================
 echo Installing the GMP numeric library '(gmp)' under /opt/opencpi/prerequisites
 scripts/install-gmp.sh
-echo ================================================================================
-echo Installing the ad9361 library under /opt/opencpi/prerequisites
-scripts/install-ad9361.sh
+#echo ================================================================================
+#echo Installing the ad9361 library under /opt/opencpi/prerequisites
+#scripts/install-ad9361.sh
 echo ================================================================================
 echo All OpenCPI prerequisites have been installed.

--- a/tools/cdk/scripts/util.sh
+++ b/tools/cdk/scripts/util.sh
@@ -36,7 +36,7 @@ function findInProjectPath {
 function setVarsFromMake {
   local quiet
   [ -z "$3" ] && quiet=1   
-  [ -z $(which make 2> /dev/null) ] && {
+  [ -z $(command -v make 2> /dev/null) ] && {
     [ -n "$3" ] && echo The '"make"' command is not available. 2>&1
     return 1
   }


### PR DESCRIPTION
I'm not sure why this says 5 commits when really there's just two. One fixes a missing "`export`" for Zed and the other disables the prereq install of AD9361 no-OS driver.